### PR TITLE
Add support for Rails 4, and re-compile translations.js when a Rails locales yml file is changed.

### DIFF
--- a/app/assets/javascripts/i18n/translations.coffee.erb
+++ b/app/assets/javascripts/i18n/translations.coffee.erb
@@ -1,3 +1,5 @@
+#= depend_on_locales
+
 locales = {}
 
 <%

--- a/config/initializers/sprockets.rb
+++ b/config/initializers/sprockets.rb
@@ -1,0 +1,7 @@
+class Sprockets::DirectiveProcessor
+  def process_depend_on_locales_directive
+    Dir.glob("#{Rails.root}/config/locales/**.yml").each do |path|
+      context.depend_on(path)
+    end
+  end
+end

--- a/rails-asset-localization.gemspec
+++ b/rails-asset-localization.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib,vendor}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 3.2.12"
+  s.add_dependency "rails", "> 3.2.12"
 end


### PR DESCRIPTION
Create a new `depend_on_locales` directive and use it in i18n/translations.js to automatically expire the asset when the Rails localization yml files are edited.  This makes local development much easier — there's no need to manually recompile assets whenever a translation changes.
