### PR TITLE
make localesExporter a static variable to avoid instantiating per request

### DIFF
--- a/app/controllers/rails_asset_localization/locales_controller.rb
+++ b/app/controllers/rails_asset_localization/locales_controller.rb
@@ -5,10 +5,13 @@ module RailsAssetLocalization
     def locale
       locale = params.fetch(:locale) { I18n.default_locale.to_s }
       locale = $1 if locale =~ /(\w+)\-(\w+)/
-
-      locales_exporter = ::RailsAssetLocalization::LocalesExporter.new
       locales = (locales_exporter.translations[locale.to_sym] || {})
       respond_with locales
+    end
+
+    def locales_exporter
+      @@locales_exporter ||= ::RailsAssetLocalization::LocalesExporter.new
+      @@locales_exporter
     end
   end
 end


### PR DESCRIPTION
We observed CPU loading is high when requesting `/locales/[locale].json`. This PR is for this.
